### PR TITLE
concatenating split[3] and split[4] will return both alleles

### DIFF
--- a/lib/parsers/Ancestry.js
+++ b/lib/parsers/Ancestry.js
@@ -20,8 +20,9 @@ module.exports = {
 
     if (split[3] !== '0') {
       snp.genotype = split[3];
-    } else if (split[4] !== '0') {
-      snp.genotype = split[4];
+    } 
+    if (split[4] !== '0') {
+      snp.genotype += split[4];
     }
 
     if (chromosomeReplacements[snp.chromosome]) {


### PR DESCRIPTION
I'm a novice, so I have no idea if this reflects good practice. I tested this out, however, and concatenating the second allele column seems to return the correct two-allele format.