### PR TITLE
encoding string required for fs.readFileSync

### DIFF
--- a/examples/toJSON.js
+++ b/examples/toJSON.js
@@ -2,7 +2,7 @@ var dna = require('../');
 var fs = require('fs');
 var path = require('path');
 
-var txt = fs.readFileSync(path.join(__dirname, 'dna.txt'));
+var txt = fs.readFileSync(path.join(__dirname, 'dna.txt'), 'utf-8');
 
 dna.parse(txt, function(err, snps){
   fs.writeFileSync(path.join(__dirname, 'dna.json'), JSON.stringify(snps));


### PR DESCRIPTION
I'm not sure how necessary this is, or if it breaks anything else. However on my system this example file will not run without explicitly providing an encoding definition as a string for fs.readFileSync.