### PR TITLE
Parser tested with Genes for Good unphased TXT results.

### DIFF
--- a/lib/parsers/GenesforGood.js
+++ b/lib/parsers/GenesforGood.js
@@ -1,0 +1,22 @@
+module.exports = {
+  matches: function(lines) {
+    return (lines[0].replace(/\s/g, '').indexOf('GenesforGood') !== -1 && lines[0].indexOf('unphased') !== -1);
+  },
+  parseLine: function(line) {
+    var split = line.split('\t');
+    var snp = {
+      id: split[0],
+      chromosome: split[1],
+      genotype: split[3]
+    };
+
+    if (snp.chromosome !== 'X' &&
+      snp.chromosome !== 'Y' &&
+      snp.chromosome !== 'MT') {
+      snp.chromosome = +snp.chromosome;
+    }
+
+    snp.genotype = snp.genotype.replace('D', '-') // fix deletions
+    return snp;
+  }
+};


### PR DESCRIPTION
A simple test for the Org name seems to work. I've tested this with Genes for Good unphased TXT files formatted in 23andMe format. If using the 23andMe parser as an alias would work better, I'd love to see how that's done.

Handling Genes for Good imputed genotype files would require dealing with the V8 memory limit, since attempting to parse those currently causes Node to crash.

Alternatively, you could just prevent those files from being used by adding something like this to the return in matches:

```
matches: function(lines) {
    return (lines[0].replace(/\s/g, '').indexOf('GenesforGood') !== -1 && lines[0].indexOf('unphased') !== -1);
  },
```