### PR TITLE
parsers: Replace all occurrences

### DIFF
--- a/lib/parsers/23andMe.js
+++ b/lib/parsers/23andMe.js
@@ -16,8 +16,8 @@ module.exports = {
       snp.chromosome = +snp.chromosome;
     }
 
-    snp.genotype = snp.genotype.replace('-', '?') // no-calls
-    snp.genotype = snp.genotype.replace('D', '-') // deletions
+    snp.genotype = snp.genotype.replace(new RegExp('-', 'g'), '?') // no-calls
+    snp.genotype = snp.genotype.replace(new RegExp('D', 'g'), '-') // deletions
     return snp;
   }
 };

--- a/lib/parsers/Ancestry.js
+++ b/lib/parsers/Ancestry.js
@@ -26,8 +26,8 @@ module.exports = {
       snp.chromosome !== 'MT') {
       snp.chromosome = +snp.chromosome;
     }
-    snp.genotype = snp.genotype.replace('0', '?') // no-calls
-    snp.genotype = snp.genotype.replace('D', '-') // deletions
+    snp.genotype = snp.genotype.replace(new RegExp('0', 'g'), '?') // no-calls
+    snp.genotype = snp.genotype.replace(new RegExp('D', 'g'), '-') // deletions
     return snp;
   }
 };

--- a/lib/parsers/FamilyTree.js
+++ b/lib/parsers/FamilyTree.js
@@ -19,8 +19,8 @@ module.exports = {
       snp.chromosome = +snp.chromosome;
     }
 
-    snp.genotype = snp.genotype.replace('-', '?') // no-calls
-    snp.genotype = snp.genotype.replace('D', '-') // deletions
+    snp.genotype = snp.genotype.replace(new RegExp('-', 'g'), '?') // no-calls
+    snp.genotype = snp.genotype.replace(new RegExp('D', 'g'), '-') // deletions
     return snp;
   }
 };

--- a/lib/parsers/GenesforGood.js
+++ b/lib/parsers/GenesforGood.js
@@ -16,8 +16,8 @@ module.exports = {
       snp.chromosome = +snp.chromosome;
     }
 
-    snp.genotype = snp.genotype.replace('-', '?') // no-calls
-    snp.genotype = snp.genotype.replace('D', '-') // deletions
+    snp.genotype = snp.genotype.replace(new RegExp('-', 'g'), '?') // no-calls
+    snp.genotype = snp.genotype.replace(new RegExp('D', 'g'), '-') // deletions
     return snp;
   }
 };


### PR DESCRIPTION
Whoops, #11 has left things broken and confused. The fix only replaced a single occurrence of `D` in raw data, resulting in `-D` in SNP-JSON. This commit fixes it.

Now things have to be changed (even without this PR):

## genomejs/genoset-male/index.js

https://github.com/genomejs/genoset-male/blob/master/index.js#L4

```
gql.exact('rs2032651', 'D');
```
This will never work, and the code must match `--` (or technically, `-D` without this PR). Note that `-I` is possible (e.g. https://www.snpedia.com/index.php/rs5030655).

## genomejs/gql/README.md

The example in [README.md](https://github.com/genomejs/gql#exactid-genotype) has the same problem.