### PR TITLE
Make dna2json browser-friendly

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,8 +1,4 @@
-var requireDir = require('require-dir');
-var path = require('path');
-var providers = requireDir(path.join(__dirname, './lib/parsers'));
-
 module.exports = {
   parse: require('./lib/parse'),
-  providers: providers
+  providers: require('./lib/parsers'),
 };

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -1,8 +1,6 @@
 var first = require('first-match');
 var reduce = require('lodash.reduce');
-var requireDir = require('require-dir');
-var path = require('path');
-var providers = requireDir(path.join(__dirname, './parsers'));
+var providers = require('./parsers');
 
 module.exports = function(dna, cb){
   if (typeof dna !== 'string') {

--- a/lib/parsers/index.js
+++ b/lib/parsers/index.js
@@ -1,0 +1,6 @@
+module.exports = {
+  '23andMe': require('./23andMe.js'),
+  'Ancestry': require('./Ancestry.js'),
+  'FamilyTree': require('./FamilyTree.js'),
+  'GenesforGood': require('./GenesforGood.js'),
+};

--- a/package.json
+++ b/package.json
@@ -24,8 +24,7 @@
   "dependencies": {
     "first-match": "0.0.1",
     "lodash.reduce": "^3.0.0",
-    "optimist": "^0.6.1",
-    "require-dir": "^0.3.0"
+    "optimist": "^0.6.1"
   },
   "engines": {
     "node": ">= 0.4.0"


### PR DESCRIPTION
This commit removes `require-dir` which depends on `fs`.

The parser list needs to hard-coded, but it makes things easier to track. Any thoughts?