### PR TITLE
Ancestry.js: Fix replacement

### DIFF
--- a/lib/parsers/Ancestry.js
+++ b/lib/parsers/Ancestry.js
@@ -1,7 +1,8 @@
 var chromosomeReplacements = {
   '23': 'X',
   '24': 'Y',
-  '25': 'PAR'
+  '25': 'PAR',
+  '26': 'MT',
 };
 
 module.exports = {
@@ -20,10 +21,7 @@ module.exports = {
     };
     if (chromosomeReplacements[snp.chromosome]) {
       snp.chromosome = chromosomeReplacements[snp.chromosome];
-    }
-    if (snp.chromosome !== 'X' &&
-      snp.chromosome !== 'Y' &&
-      snp.chromosome !== 'MT') {
+    } else {
       snp.chromosome = +snp.chromosome;
     }
     snp.genotype = snp.genotype.replace(new RegExp('0', 'g'), '?') // no-calls


### PR DESCRIPTION
23 -> X
24 -> Y
25 -> PAR
26 -> MT

Reference:
http://archiver.rootsweb.ancestry.com/th/read/GENEALOGY-DNA/2016-06/1465575396
https://www.reddit.com/r/Genealogy/comments/5y90un/why_is_my_ancestrydna_raw_data_showing_me_as/

By the way, the vendor information in `README.md` is out-of-date. 23andMe v4 (since Nov 2013) now has 598897 SNPs (574056 autosomal, 19425 X, 2129 Y, 3287 MT), and AncestryDNA v2 (since May 2016) now has 668942 SNPs (637639 autosomal, 195 MT). Ancestry reports SNPs on the pseudoautosomal region as "chromosome 25," as opposed to 23andMe which reports them on the X and Y chromosomes, so it's a bit difficult to get the exact numbers. Maybe someone can get it straight?
